### PR TITLE
Update versions for node, upload-artifact

### DIFF
--- a/.github/workflows/delete_theme.yml
+++ b/.github/workflows/delete_theme.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci --prefix ./.github/workflows/scripts/

--- a/.github/workflows/export_theme.yml
+++ b/.github/workflows/export_theme.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci --prefix ./.github/workflows/scripts/
@@ -40,7 +40,8 @@ jobs:
           ZENDESK_TOKEN: ${{ secrets.ZENDESK_TOKEN }}
 
       - name: Upload theme file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: theme-file
           path: ./theme_${{ github.event.inputs.themeId }}.zip

--- a/.github/workflows/import_theme.yml
+++ b/.github/workflows/import_theme.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci --prefix ./.github/workflows/scripts/
@@ -50,7 +50,8 @@ jobs:
           ZENDESK_TOKEN: ${{ secrets.ZENDESK_TOKEN }}
 
       - name: Upload theme file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: theme-file
           path: ./.github/workflows/scripts/theme.zip

--- a/.github/workflows/list_themes.yml
+++ b/.github/workflows/list_themes.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci --prefix ./.github/workflows/scripts/

--- a/.github/workflows/publish_theme.yml
+++ b/.github/workflows/publish_theme.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci --prefix ./.github/workflows/scripts/

--- a/.github/workflows/show_theme.yml
+++ b/.github/workflows/show_theme.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci --prefix ./.github/workflows/scripts/

--- a/.github/workflows/update_theme.yml
+++ b/.github/workflows/update_theme.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci --prefix ./.github/workflows/scripts/
@@ -60,7 +60,8 @@ jobs:
           ZENDESK_TOKEN: ${{ secrets.ZENDESK_TOKEN }}
 
       - name: Upload theme file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: theme-file
           path: ./.github/workflows/scripts/theme.zip


### PR DESCRIPTION
This PR bumps the node version for the workflows from 14.x to 20.x (which GitHub automatically applies to actions using 16.x or older). It also updates the upload-artifact version to v4 because of the impending v3 deprecation: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/